### PR TITLE
BEYONDWORM-48 잘못된 배포 설정 수정

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,5 +23,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./FE/dist
+          publish_dir: ./web-io-game/dist
           publish_branch: gh-pages


### PR DESCRIPTION
publish_dir를 예제를 보고 따라하다가 그대로 복붙해서 틀렸네요 ㅋㅋㅋ...
어쩐지 깃헙 액션은 성공했는데 배포가 안되더라구요