### PR TITLE
BEYONDWORM-52 플레이어 머리를 노리는 봇이 간헐적으로 바보가 되는 버그

### DIFF
--- a/web-io-game/src/client/GameScene.ts
+++ b/web-io-game/src/client/GameScene.ts
@@ -344,6 +344,7 @@ export default class GameScene extends Phaser.Scene {
         for (const segment of wormState.segments) {
             segment.destroy();
         }
+        wormState.nextTarget = null; // 다음 스폰때 타겟이 재할당될 수 있도록 초기화
 
         // 스포너에 반환
         this.wormSpawner.releaseWorm(wormType, wormState);

--- a/web-io-game/src/client/GameScene.ts
+++ b/web-io-game/src/client/GameScene.ts
@@ -344,7 +344,6 @@ export default class GameScene extends Phaser.Scene {
         for (const segment of wormState.segments) {
             segment.destroy();
         }
-        wormState.nextTarget = null; // 다음 스폰때 타겟이 재할당될 수 있도록 초기화
 
         // 스포너에 반환
         this.wormSpawner.releaseWorm(wormType, wormState);

--- a/web-io-game/src/client/WormSpawner.ts
+++ b/web-io-game/src/client/WormSpawner.ts
@@ -58,6 +58,7 @@ export default class WormSpawner {
         wormState.path = [];
         wormState.lastVel.set(0, 1);
         wormState.lastHead.set(x, y);
+        wormState.nextTarget = null;
 
         // 세그먼트 생성
         for (let i = 0; i < GAME_CONSTANTS.SEGMENT_DEFAULT_COUNT; i++) {


### PR DESCRIPTION
지렁이가 죽었다가 다음에 스폰됐을때 이전 타겟정보가 남아있어서 타겟이 제대로 갱신이 안되는 이슈 해결