### PR TITLE
BEYONDWORM-62 벌레 성장 반지름 조금 축소시키기

### DIFF
--- a/web-io-game/src/client/constants.ts
+++ b/web-io-game/src/client/constants.ts
@@ -8,7 +8,7 @@ export const GAME_CONSTANTS = {
     SEGMENT_DEFAULT_COUNT: 5, // 기본 세그먼트(원) 개수
     SEGMENT_MAX_COUNT: 25, // 최대 세그먼트(원) 개수
     SEGMENT_DEFAULT_RADIUS: 40, // 기본 세그먼트(원) 반지름(px)
-    SEGMENT_GROWTH_RADIUS: 2, // 먹이를 먹을 때 세그먼트 반지름 증가량(px)
+    SEGMENT_GROWTH_RADIUS: 1.5, // 먹이를 먹을 때 세그먼트 반지름 증가량(px)
 
     HEAD_SPEED: 350, // 머리가 마우스를 쫓는 속도(px/s)
     HEAD_SPRINT_SPEED: 550, // 달리기 속도


### PR DESCRIPTION
벌레의 성장폭이 커서 조금만 점수를 따도 확커진다 성장률을 25% 감소 시켰다