### PR TITLE
BEYONDWORM-96 지렁이가 달리거나 죽으면 먹은 먹이를 뱉도록 수정

### DIFF
--- a/game-server/src/game/engine.ts
+++ b/game-server/src/game/engine.ts
@@ -37,6 +37,10 @@ export function updateFoods(foods: Map<string, Food>): void {
     }
 }
 
+function updateWormRadius(worm: Worm): void {
+    worm.radius = worm.score * GAME_CONSTANTS.SEGMENT_GROWTH_RADIUS + GAME_CONSTANTS.SEGMENT_DEFAULT_RADIUS;
+}
+
 /**
  * 지렁이가 먹이를 먹었을 때의 처리를 합니다.
  */
@@ -44,8 +48,7 @@ export function processFoodEaten(worm: Worm): void {
     // 점수 증가
     worm.score += 1;
 
-    // 세그먼트 반지름 증가
-    worm.radius = worm.score * GAME_CONSTANTS.SEGMENT_GROWTH_RADIUS + GAME_CONSTANTS.SEGMENT_DEFAULT_RADIUS;
+    updateWormRadius(worm); // 반지름 업데이트
 
     // 새 세그먼트 추가
     const lastSegment = worm.segments[worm.segments.length - 1];
@@ -439,7 +442,7 @@ function checkHeadToBodyCollision(headWorm: Worm, bodyWorm: Worm): boolean {
 export function handleSprintFoodDrop(worms: Map<string, Worm>, foods: Map<string, Food>, dt: number): void {
     for (const worm of worms.values()) {
         // 스프린트중이면서 죽지 않았고 점수가 0 이상인 지렁이만 처리
-        if (!worm.isSprinting || worm.isDead || worm.score == 0) continue;
+        if (!worm.isSprinting || worm.isDead || worm.score <= 0) continue;
 
         worm.sprintFoodDropTimer += dt * 1000; // ms 단위로 타이머 증가
 
@@ -455,7 +458,7 @@ export function handleSprintFoodDrop(worms: Map<string, Worm>, foods: Map<string
 
                 // 점수 감소
                 worm.score = Math.max(0, worm.score - 1);
-                worm.radius = worm.score * GAME_CONSTANTS.SEGMENT_GROWTH_RADIUS + GAME_CONSTANTS.SEGMENT_DEFAULT_RADIUS;
+                updateWormRadius(worm); // 반지름 업데이트
 
                 console.log(
                     `🏃 Sprint food drop: Worm ${worm.id} dropped food at (${tailSegment.x}, ${tailSegment.y})`,
@@ -469,7 +472,7 @@ export function handleSprintFoodDrop(worms: Map<string, Worm>, foods: Map<string
  * 지렁이가 죽을 때 몸통을 따라 먹이를 떨어뜨립니다.
  */
 export function dropFoodOnDeath(worm: Worm, foods: Map<string, Food>): void {
-    const foodCount = worm.score / 2; // 죽을 때 점수의 반만큼 먹이 생성
+    const foodCount = Math.floor(worm.score / 2); // 죽을 때 점수의 반만큼 먹이 생성
 
     if (foodCount <= 0) return;
 

--- a/game-server/src/game/engine.ts
+++ b/game-server/src/game/engine.ts
@@ -2,19 +2,29 @@ import { GAME_CONSTANTS, Worm, WormType, Food, BotType } from "@beyondworm/share
 import { MovementStrategy } from "../types/movement";
 import { getAngleDifference, vectorToAngle, angleToVector } from "../utils/math";
 import { v4 as uuidv4 } from "uuid";
-import { createBotWorm, createMovementStrategy, createPlayerWorm, createWormSegments } from "../worm/factory";
+import { createBotWorm, createMovementStrategy, createPlayerWorm } from "../worm/factory";
+
+/**
+ * 특정 위치에 먹이를 생성합니다.
+ */
+export function createFoodAtPosition(x: number, y: number): Food {
+    return {
+        id: `food_${uuidv4()}`,
+        x: x,
+        y: y,
+        radius: GAME_CONSTANTS.FOOD_RADIUS,
+        color: GAME_CONSTANTS.FOOD_COLOR,
+    };
+}
 
 /**
  * 랜덤 먹이를 생성합니다.
  */
 export function createRandomFood(): Food {
-    return {
-        id: `food_${uuidv4()}`,
-        x: Math.random() * (GAME_CONSTANTS.MAP_WIDTH - 200) + 100,
-        y: Math.random() * (GAME_CONSTANTS.MAP_HEIGHT - 200) + 100,
-        radius: GAME_CONSTANTS.FOOD_RADIUS,
-        color: GAME_CONSTANTS.FOOD_COLOR, // 빨간색
-    };
+    return createFoodAtPosition(
+        Math.random() * (GAME_CONSTANTS.MAP_WIDTH - 200) + 100,
+        Math.random() * (GAME_CONSTANTS.MAP_HEIGHT - 200) + 100,
+    );
 }
 
 /**
@@ -35,16 +45,13 @@ export function processFoodEaten(worm: Worm): void {
     worm.score += 1;
 
     // 세그먼트 반지름 증가
-    for (const segment of worm.segments) {
-        segment.radius += GAME_CONSTANTS.SEGMENT_GROWTH_RADIUS;
-    }
+    worm.radius = worm.score * GAME_CONSTANTS.SEGMENT_GROWTH_RADIUS + GAME_CONSTANTS.SEGMENT_DEFAULT_RADIUS;
 
     // 새 세그먼트 추가
     const lastSegment = worm.segments[worm.segments.length - 1];
     worm.segments.push({
         x: lastSegment.x,
         y: lastSegment.y,
-        radius: GAME_CONSTANTS.SEGMENT_DEFAULT_RADIUS + GAME_CONSTANTS.SEGMENT_GROWTH_RADIUS * worm.score,
     });
 }
 
@@ -107,7 +114,8 @@ function updateWormHead(worm: Worm, deltaTime: number): void {
         const normalizedDirX = dirX / magnitude;
         const normalizedDirY = dirY / magnitude;
 
-        const speed = worm.isSprinting ? GAME_CONSTANTS.HEAD_SPRINT_SPEED : GAME_CONSTANTS.HEAD_SPEED;
+        // 스프린트 중이면서 점수가 0 이상일 때만 스프린트 속도 적용
+        const speed = worm.isSprinting && worm.score > 0 ? GAME_CONSTANTS.HEAD_SPRINT_SPEED : GAME_CONSTANTS.HEAD_SPEED;
 
         // 머리 위치 업데이트
         const head = worm.segments[0];
@@ -208,7 +216,7 @@ export function validateAndProcessFoodEaten(
 
     // 먹이와의 실제 거리 검증
     const foodDistance = Math.hypot(head.x - food.x, head.y - food.y);
-    const collisionDistance = head.radius + food.radius;
+    const collisionDistance = worm.radius + food.radius;
 
     // 머리 중심좌표로 부터 먹이 중심좌표까지의 거리가 머리와 먹이의 반지름 합에 약간의 보정치를 더한값보다 크면 검증실패
     if (foodDistance > collisionDistance + GAME_CONSTANTS.MAX_COLLISION_TOLERANCE) {
@@ -242,7 +250,7 @@ export function handleBotFoodCollisions(
 
         for (const food of foods.values()) {
             const distance = Math.hypot(head.x - food.x, head.y - food.y);
-            const collisionDistance = head.radius + food.radius;
+            const collisionDistance = worm.radius + food.radius;
 
             if (distance < collisionDistance) {
                 // 봇이 먹이를 먹음
@@ -322,8 +330,12 @@ function respawnPlayer(worm: Worm): void {
 /**
  * 지렁이를 죽이고 다음 틱이 시작되면 되살림
  */
-function killWorm(worm: Worm): void {
+function killWorm(worm: Worm, foods: Map<string, Food>): void {
     console.log(`💀 Killing worm: ${worm.id}`);
+
+    // 죽기 전에 먹이 떨어뜨리기
+    dropFoodOnDeath(worm, foods);
+
     worm.isDead = true;
 }
 
@@ -334,6 +346,7 @@ export function validateAndProcessCollision(
     reporterWormId: string,
     colliderWormId: string,
     worms: Map<string, Worm>,
+    foods: Map<string, Food>,
 ): boolean {
     const reporterWorm = worms.get(reporterWormId);
     const colliderWorm = worms.get(colliderWormId);
@@ -349,7 +362,7 @@ export function validateAndProcessCollision(
 
     // 충돌자의 머리가 리포터의 몸통(머리 제외)과 충돌했는지 검증
     if (checkHeadToBodyCollision(colliderWorm, reporterWorm)) {
-        killWorm(colliderWorm);
+        killWorm(colliderWorm, foods);
         console.log(`✅ Collision validated: ${colliderWormId} died by hitting ${reporterWormId}`);
         return true;
     }
@@ -361,7 +374,10 @@ export function validateAndProcessCollision(
 /**
  * 서버에서 직접 모든 지렁이 간의 충돌을 감지하고 처리합니다.
  */
-export function handleWormCollisions(worms: Map<string, Worm>): { killedWormId: string; killerWormId: string }[] {
+export function handleWormCollisions(
+    worms: Map<string, Worm>,
+    foods: Map<string, Food>,
+): { killedWormId: string; killerWormId: string }[] {
     const collisionsToProcess: { killed: Worm; killer: Worm }[] = [];
     const allWorms = Array.from(worms.values());
 
@@ -385,7 +401,7 @@ export function handleWormCollisions(worms: Map<string, Worm>): { killedWormId: 
 
     for (const { killed, killer } of collisionsToProcess) {
         if (!killed.isDead && !killedThisTick.has(killed.id)) {
-            killWorm(killed);
+            killWorm(killed, foods);
             killedThisTick.add(killed.id);
             finalCollisions.push({ killedWormId: killed.id, killerWormId: killer.id });
             console.log(`💥 Server collision: ${killed.id} died by hitting ${killer.id}'s body`);
@@ -402,12 +418,12 @@ function checkHeadToBodyCollision(headWorm: Worm, bodyWorm: Worm): boolean {
     if (headWorm.id === bodyWorm.id) return false; // 같은 지렁이 제외
 
     const head = headWorm.segments[0];
+    const collisionDistance = headWorm.radius + bodyWorm.radius;
 
     // 머리가 다른 지렁이의 몸통(머리 제외)과 충돌했는지 확인
     for (let i = 1; i < bodyWorm.segments.length; i++) {
         const segment = bodyWorm.segments[i];
         const distance = Math.hypot(head.x - segment.x, head.y - segment.y);
-        const collisionDistance = head.radius + segment.radius;
 
         if (distance < collisionDistance + GAME_CONSTANTS.MAX_COLLISION_TOLERANCE) {
             return true;
@@ -415,4 +431,56 @@ function checkHeadToBodyCollision(headWorm: Worm, bodyWorm: Worm): boolean {
     }
 
     return false;
+}
+
+/**
+ * 스프린트 중인 지렁이의 먹이 떨어뜨리기를 처리합니다.
+ */
+export function handleSprintFoodDrop(worms: Map<string, Worm>, foods: Map<string, Food>, dt: number): void {
+    for (const worm of worms.values()) {
+        // 스프린트중이면서 죽지 않았고 점수가 0 이상인 지렁이만 처리
+        if (!worm.isSprinting || worm.isDead || worm.score == 0) continue;
+
+        worm.sprintFoodDropTimer += dt * 1000; // ms 단위로 타이머 증가
+
+        // 달린지 충분한 시간이 지났으면 먹이 떨어뜨리기
+        if (worm.sprintFoodDropTimer >= GAME_CONSTANTS.SPRINT_FOOD_DROP_INTERVAL) {
+            worm.sprintFoodDropTimer -= GAME_CONSTANTS.SPRINT_FOOD_DROP_INTERVAL;
+            // 꼬리 세그먼트 제거
+            const tailSegment = worm.segments.pop();
+            if (tailSegment) {
+                // 제거된 꼬리 위치에 먹이 생성
+                const food = createFoodAtPosition(tailSegment.x, tailSegment.y);
+                foods.set(food.id, food);
+
+                // 점수 감소
+                worm.score = Math.max(0, worm.score - 1);
+                worm.radius = worm.score * GAME_CONSTANTS.SEGMENT_GROWTH_RADIUS + GAME_CONSTANTS.SEGMENT_DEFAULT_RADIUS;
+
+                console.log(
+                    `🏃 Sprint food drop: Worm ${worm.id} dropped food at (${tailSegment.x}, ${tailSegment.y})`,
+                );
+            }
+        }
+    }
+}
+
+/**
+ * 지렁이가 죽을 때 몸통을 따라 먹이를 떨어뜨립니다.
+ */
+export function dropFoodOnDeath(worm: Worm, foods: Map<string, Food>): void {
+    const foodCount = worm.score / 2; // 죽을 때 점수의 반만큼 먹이 생성
+
+    if (foodCount <= 0) return;
+
+    // 세그먼트들 중에서 균등하게 분배하여 먹이 생성
+    const step = Math.max(1, Math.floor(worm.segments.length / foodCount));
+
+    for (let i = 0; i < worm.segments.length; i += step) {
+        const segment = worm.segments[i];
+        const food = createFoodAtPosition(segment.x, segment.y);
+        foods.set(food.id, food);
+    }
+
+    console.log(`💀 Death food drop: Worm ${worm.id} dropped about ${foodCount} foods`);
 }

--- a/game-server/src/index.ts
+++ b/game-server/src/index.ts
@@ -5,7 +5,14 @@ import { Server as SocketIOServer } from "socket.io";
 import { GAME_CONSTANTS, Worm, BotType, Food, WormType } from "@beyondworm/shared";
 import { MovementStrategy } from "./types/movement";
 import { createBotWorm, createMovementStrategy } from "./worm/factory";
-import { updateWorld, updateFoods, handleBotFoodCollisions, handleRespawns, handleWormCollisions } from "./game/engine";
+import {
+    updateWorld,
+    updateFoods,
+    handleBotFoodCollisions,
+    handleRespawns,
+    handleWormCollisions,
+    handleSprintFoodDrop,
+} from "./game/engine";
 import { setupSocketHandlers } from "./socket/handlers";
 
 dotenv.config(); // .env 로드
@@ -137,11 +144,14 @@ function updateAndBroadcastGameState(
     // 부활 처리
     handleRespawns(worms, targetDirections, botMovementStrategies);
 
+    // 스프린트 중 먹이 떨어뜨리기 처리
+    handleSprintFoodDrop(worms, foods, deltaTime);
+
     // 지렁이 상태 업데이트
     updateWorld(deltaTime, worms, foods, targetDirections, botMovementStrategies);
 
     // 서버에서 직접 모든 지렁이 간의 충돌 감지 및 처리
-    const wormCollisions = handleWormCollisions(worms);
+    const wormCollisions = handleWormCollisions(worms, foods);
 
     // 지렁이 충돌이 발생했다면 클라이언트들에게 알림
     if (wormCollisions.length > 0) {

--- a/game-server/src/socket/handlers.ts
+++ b/game-server/src/socket/handlers.ts
@@ -142,9 +142,10 @@ function handleCollisionReport(
     io: SocketIOServer,
     data: { colliderWormId: string },
     worms: Map<string, Worm>,
+    foods: Map<string, Food>,
 ): void {
     // 클라이언트 리포트 기반으로 충돌 검증 및 처리
-    const success = validateAndProcessCollision(socket.id, data.colliderWormId, worms);
+    const success = validateAndProcessCollision(socket.id, data.colliderWormId, worms, foods);
 
     if (success) {
         // 검증 성공 - 모든 클라이언트에게 지렁이가 죽었음을 알림
@@ -188,7 +189,7 @@ export function setupSocketHandlers(
 
         // 충돌 리포트 이벤트 (리포트 기반 처리)
         socket.on("collision-report", (data: { colliderWormId: string }) => {
-            handleCollisionReport(socket, io, data, worms);
+            handleCollisionReport(socket, io, data, worms, foods);
         });
 
         // 스프린트 이벤트들

--- a/game-server/src/worm/factory.ts
+++ b/game-server/src/worm/factory.ts
@@ -29,7 +29,6 @@ function createWormSegments(): WormSegment[] {
         segments.push({
             x: startPosition.x - i * GAME_CONSTANTS.SEGMENT_SPACING,
             y: startPosition.y,
-            radius: GAME_CONSTANTS.SEGMENT_DEFAULT_RADIUS,
         });
     }
     return segments;
@@ -85,6 +84,8 @@ export function createBotWorm(botType: BotType): Worm {
         isSprinting: false,
         color: getRandomBotColor(),
         isDead: false,
+        radius: GAME_CONSTANTS.SEGMENT_DEFAULT_RADIUS,
+        sprintFoodDropTimer: 0,
     };
 }
 
@@ -102,5 +103,7 @@ export function createPlayerWorm(playerId: string): Worm {
         isSprinting: false,
         color: 0xff0000, // 플레이어는 빨간색
         isDead: false,
+        radius: GAME_CONSTANTS.SEGMENT_DEFAULT_RADIUS,
+        sprintFoodDropTimer: 0,
     };
 }

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -13,7 +13,6 @@ export enum BotType {
 export interface WormSegment {
     x: number;
     y: number;
-    radius: number;
 }
 
 export interface Food {
@@ -35,6 +34,8 @@ export interface Worm {
     isSprinting: boolean;
     color: number; // 지렁이 색상
     isDead: boolean; // 죽음 상태
+    radius: number;
+    sprintFoodDropTimer: number; // 먹이를 떨어트리는 타이밍을 측정하기위해 스프린팅 시간을 누적한다
 }
 
 export interface GameRoom {

--- a/web-io-game/src/GameScene.ts
+++ b/web-io-game/src/GameScene.ts
@@ -173,7 +173,7 @@ export default class GameScene extends Phaser.Scene {
 
         for (let i = 0; i < serverWorm.segments.length; i++) {
             const serverSegment = serverWorm.segments[i];
-            const segment = this.add.circle(serverSegment.x, serverSegment.y, serverSegment.radius, serverWorm.color);
+            const segment = this.add.circle(serverSegment.x, serverSegment.y, serverWorm.radius, serverWorm.color);
             segment.setStrokeStyle(4, 0x333333);
             segment.setDepth(FE_CONSTANTS.ZORDER_SEGMENT - i);
 
@@ -234,22 +234,12 @@ export default class GameScene extends Phaser.Scene {
             const clientSegment = clientWorm.segments[i];
             const serverSegment = serverWorm.segments[i];
 
-            clientSegment.x = Phaser.Math.Linear(
-                clientSegment.x,
-                serverSegment.x,
-                FE_CONSTANTS.WORM_POSITION_LERP_FACTOR,
-            );
-            clientSegment.y = Phaser.Math.Linear(
-                clientSegment.y,
-                serverSegment.y,
-                FE_CONSTANTS.WORM_POSITION_LERP_FACTOR,
-            );
+            clientSegment.x = serverSegment.x;
+            clientSegment.y = serverSegment.y;
 
-            // 반지름 보간
-            const newRadius = Phaser.Math.Linear(clientSegment.radius, serverSegment.radius, 0.1);
-            clientSegment.setRadius(newRadius);
+            clientSegment.setRadius(serverWorm.radius);
             if (clientSegment.body) {
-                (clientSegment.body as Phaser.Physics.Arcade.Body).setCircle(newRadius);
+                (clientSegment.body as Phaser.Physics.Arcade.Body).setCircle(serverWorm.radius);
             }
         }
 


### PR DESCRIPTION
1. 지렁이가 달리기를 하면 0.5초에 한번씩 먹이를 떨어트리고 크기가 작아져야함
2. 점수가 0점 이상일때만 달릴수 있도록 제약 추가
3. 지렁이가 죽으면 몸 경로를 따라 먹은 먹이에 비례하는 먹이를 떨어트려야함
4. 지렁이의 몸통 각각이 Radius를 가지는게 아닌 지렁이의 상태로 관리해서 몸통의 크기 공통화
5. FE와 BE의 몸통 크기 차이로 인한 버그 수정을 위해 FE는 BE가 보내는 몸통 위치와 크기를 그대로 사용하도록 수정
