### PR TITLE
BEYONDWORM-109 : 빌드 에러 수정.

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          dockerfile: ./lobby-server/Dockerfile
+          file: ./lobby-server/Dockerfile
           push: true
           tags: ghcr.io/beyond-imagination/beyondworm-lobby-server:latest
 
@@ -36,6 +36,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          dockerfile: ./game-server/Dockerfile
+          file: ./game-server/Dockerfile
           push: true
           tags: ghcr.io/beyond-imagination/beyondworm-game-server:latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,6 +14,9 @@ jobs:
       pages: write
       id-token: write
 
+    environment:
+      name: github-pages
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
1. pages : workflow의 environment 정보가 없어서 에러. 추가함.
2. build and deploy : 'docker/build-push-action@v5' 부터는 docker:가 아니라 file:을 써야한다고합니다.

추가로 저희 github setting의 Pages에서 Build and deployment부분을 'Github Actions'로 변경했습니다.


이.... 이번엔 될겁니다...!